### PR TITLE
Update rotp dependency from exactly 2.0 to at least 5.0

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport',  '< 6.1'
   s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 4', '!= 2'
   s.add_runtime_dependency 'devise',         '~> 4.0'
-  s.add_runtime_dependency 'rotp',           '~> 2.0'
+  s.add_runtime_dependency 'rotp',           '>= 5.0'
 
   s.add_development_dependency 'activemodel'
   s.add_development_dependency 'appraisal'

--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -32,7 +32,7 @@ module Devise
         return false unless code.present? && otp_secret.present?
 
         totp = self.otp(otp_secret)
-        return consume_otp! if totp.verify_with_drift(code, self.class.otp_allowed_drift)
+        return consume_otp! if totp.verify(code, drift_ahead: self.class.otp_allowed_drift)
 
         false
       end
@@ -78,7 +78,7 @@ module Devise
                                     :otp_secret_encryption_key)
 
         def generate_otp_secret(otp_secret_length = self.otp_secret_length)
-          ROTP::Base32.random_base32(otp_secret_length)
+          ROTP::Base32.random(otp_secret_length * 5/8)
         end
       end
     end

--- a/lib/devise_two_factor/version.rb
+++ b/lib/devise_two_factor/version.rb
@@ -1,3 +1,3 @@
 module DeviseTwoFactor
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.1.0.1'.freeze
 end


### PR DESCRIPTION
Related: https://github.com/Zetatango/zetatango/issues/12468

devise-two-factor does not seem to be maintained and rotp was locked to a very old version, 2.0

Last change to the master branch of devise-two-factor was Aug 7 2019: https://github.com/tinfoil/devise-two-factor
People have been requesting rotp to be updated since Feb 2018: https://github.com/tinfoil/devise-two-factor/issues/124
There has been a PR from someone else to update dependency to 4.0 since Mar 2020 that hasn't been commented on: https://github.com/tinfoil/devise-two-factor/pull/167

I've set up a fork with a basic circleci config that runs rspec to make sure tests still pass.
Manually tested that no breaking change to existing user with authenticator app (i.e. can still log in with existing setup).  Roadrunner PR to point to new version to come.

This is the first PR with changes to tinfoil/master.  This PR sets rotp version to >= 5.0 and addresses necessary changes.  Specific comments are inline.