### PR TITLE
~> 3.1.0.2 - Restore drift to two-sided

### DIFF
--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -32,7 +32,7 @@ module Devise
         return false unless code.present? && otp_secret.present?
 
         totp = self.otp(otp_secret)
-        return consume_otp! if totp.verify(code, drift_ahead: self.class.otp_allowed_drift)
+        return consume_otp! if totp.verify(code, drift_ahead: self.class.otp_allowed_drift, drift_behind: self.class.otp_allowed_drift)
 
         false
       end

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -76,8 +76,13 @@ RSpec.shared_examples 'two_factor_authenticatable' do
       expect(subject.validate_and_consume_otp!(otp)).to be false
     end
 
-    it 'validates an OTP within the allowed drift' do
+    it 'validates an OTP within the allowed drift, ahead' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift)
+      expect(subject.validate_and_consume_otp!(otp)).to be true
+    end
+
+    it 'validates an OTP within the allowed drift, behind' do
+      otp = ROTP::TOTP.new(otp_secret).at(Time.now - subject.class.otp_allowed_drift)
       expect(subject.validate_and_consume_otp!(otp)).to be true
     end
 

--- a/lib/devise_two_factor/version.rb
+++ b/lib/devise_two_factor/version.rb
@@ -1,3 +1,3 @@
 module DeviseTwoFactor
-  VERSION = '3.1.0.1'.freeze
+  VERSION = '3.1.0.2'.freeze
 end


### PR DESCRIPTION
Addendum to https://github.com/Zetatango/zetatango/issues/12468

The old `verify_with_drift` method had a single parameter that set a two-sided drift.  It now takes a `drift_ahead` and a `drift_behind`, but I overlooked the latter, which caused people to have trouble logging in with SMS due to delay in sending codes.