### PR TITLE
Upgrade to allow rails 6.1.x

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'railties',       '< 6.1'
-  s.add_runtime_dependency 'activesupport',  '< 6.1'
+  s.add_runtime_dependency 'railties',       '< 6.2'
+  s.add_runtime_dependency 'activesupport',  '< 6.2'
   s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 4', '!= 2'
   s.add_runtime_dependency 'devise',         '~> 4.0'
   s.add_runtime_dependency 'rotp',           '>= 5.0'


### PR DESCRIPTION
Need to update dependency to allow Rails 6.1
Roadrunner PR pointing to this branch passing all tests: https://github.com/Zetatango/roadrunner/pull/1900/files
Ticket: https://github.com/Zetatango/zetatango/issues/14102